### PR TITLE
add example of weighting within priority not working

### DIFF
--- a/examples/locality-load-balancing/envoy-proxy.yaml
+++ b/examples/locality-load-balancing/envoy-proxy.yaml
@@ -39,6 +39,8 @@ static_resources:
   - name: backend
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
+    common_lb_config:
+      locality_weighted_lb_config:
     health_checks:
     - interval: 2s
       timeout: 3s
@@ -55,7 +57,7 @@ static_resources:
           region: local
           zone: zone-1
         load_balancing_weight: 2
-        priority: 0  # highest
+        priority: 1  # highest
         lb_endpoints:
         - endpoint:
             address:
@@ -69,7 +71,7 @@ static_resources:
           region: local
           zone: zone-2
         load_balancing_weight: 1
-        priority: 0
+        priority: 1
         lb_endpoints:
         - endpoint:
             address:

--- a/examples/locality-load-balancing/envoy-proxy.yaml
+++ b/examples/locality-load-balancing/envoy-proxy.yaml
@@ -54,7 +54,7 @@ static_resources:
       - locality:
           region: local
           zone: zone-1
-        load_balancing_weight: 1
+        load_balancing_weight: 2
         priority: 0  # highest
         lb_endpoints:
         - endpoint:
@@ -69,7 +69,7 @@ static_resources:
           region: local
           zone: zone-2
         load_balancing_weight: 1
-        priority: 1
+        priority: 0
         lb_endpoints:
         - endpoint:
             address:
@@ -79,31 +79,3 @@ static_resources:
             health_check_config:
               port_value: 8080
             hostname: backend-local-2
-      - locality:
-          region: remote
-          zone: zone-1
-        load_balancing_weight: 1
-        priority: 1
-        lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: backend-remote-1
-                port_value: 8080
-            health_check_config:
-              port_value: 8080
-            hostname: backend-remote-1
-      - locality:
-          region: remote
-          zone: zone-2
-        load_balancing_weight: 1
-        priority: 2
-        lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: backend-remote-2
-                port_value: 8080
-            health_check_config:
-              port_value: 8080
-            hostname: backend-remote-2

--- a/examples/locality-load-balancing/envoy-proxy.yaml
+++ b/examples/locality-load-balancing/envoy-proxy.yaml
@@ -57,7 +57,7 @@ static_resources:
           region: local
           zone: zone-1
         load_balancing_weight: 2
-        priority: 1  # highest
+        priority: 0  # highest
         lb_endpoints:
         - endpoint:
             address:
@@ -71,7 +71,7 @@ static_resources:
           region: local
           zone: zone-2
         load_balancing_weight: 1
-        priority: 1
+        priority: 0
         lb_endpoints:
         - endpoint:
             address:


### PR DESCRIPTION
When using `load_balancing_weight` with the same priority as outlined in [these docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight#:~:text=Assume%20a%20simple%20set%2Dup%20with%202%20localities%20X%20and%20Y%2C%20where%20X%20has%20a%20locality%20weight%20of%201%20and%20Y%20has%20a%20locality%20weight%20of%202%2C%20L%3DY%20100%25%20available%2C%20with%20default%20overprovisioning%20factor%201.4.), the results are not as expected. Having one priority 0 with weight 1, and one with weight 2 should yield 33% and 67% traffic, however that is not what is seen:

```
$ docker-compose exec -T client-envoy python3 client.py http://localhost:3000/ 100

Hello from backend-local-2!: actual weight 50.0%
Hello from backend-local-1!: actual weight 50.0%
Failed: 0
```

(note: just removed the other endpoints for clarity, the only part that matters is switching to have 2 items in priority 0, and with different load_balancing_weight numbers)